### PR TITLE
Added heading in module and controller files to fix duplicate titles

### DIFF
--- a/drupalup_controller.module
+++ b/drupalup_controller.module
@@ -7,7 +7,7 @@ function drupalup_controller_theme($existing, $type, $theme, $path) {
 
   return array(
     'article_list' => array(
-      'variables' => array('items' => array(), 'title' => '')
+      'variables' => array('items' => array(), 'title' => '', 'heading' => '')
     )
   );
 }

--- a/src/Controller/ArticleController.php
+++ b/src/Controller/ArticleController.php
@@ -16,7 +16,7 @@ class ArticleController {
     return array(
       '#theme' => 'article_list',
       '#items' => $items,
-      '#title' => 'Our article list'
+      '#heading' => 'Our article list'
     );
   }
 }

--- a/templates/article-list.html.twig
+++ b/templates/article-list.html.twig
@@ -1,4 +1,4 @@
-<h4>{{ title }}</h4>
+<h4>{{ heading }}</h4>
 <ul>
 {% for article in items %}
   <li>{{ article.name }}</li>


### PR DESCRIPTION
The page will now display "Our custom Article List" and "Our article list" instead of "Our article list" twice.